### PR TITLE
Feat : 다이어리 세부내용 보기 API 추가

### DIFF
--- a/src/app/Diary/diaryController.js
+++ b/src/app/Diary/diaryController.js
@@ -1,7 +1,17 @@
 import { errResponse, response } from '../../../config/response';
 import baseResponse from '../../../config/baseResponseStatus';
-import { retrieveDiaryList } from './diaryProvider';
-import { createDiary, modifyDiary, deleteDiaryCheck } from "./diaryService";
+import {
+    retrieveDiaryList,
+    retrieveDiaryTitle,
+    retrieveDiaryHashtag,
+    retrieveDiaryDefault,
+    retrieveDiaryContent
+} from './diaryProvider';
+import {
+    createDiary,
+    modifyDiary,
+    deleteDiaryCheck
+} from "./diaryService";
 
 
 export const getDiaryListAll = async (req, res) => {
@@ -22,6 +32,24 @@ export const getDiaryList = async (req, res) => {
     const getListResponse = await retrieveDiaryList(user_id);
     return res.send(getListResponse);
 };
+
+export const getDiaryDetail = async (req, res) => {
+    const { diary_id } = req.params;
+    //빈 다이어리 아이디 체크
+    if (!diary_id) return res.send(errResponse(baseResponse.DIARY_DIARYID_EMPTY));
+
+    const successResponse = baseResponse.SUCCESS;
+    const getDiaryTitleResponse = await retrieveDiaryTitle(diary_id);
+    // 다이어리가 없는 경우
+    if(!getDiaryTitleResponse[0]) return res.send(errResponse(baseResponse.DAIRY_DIARYID_NOT_EXIST));
+    const getDiaryHashtagResponse = await retrieveDiaryHashtag(diary_id);
+    const getDiaryDefaultResponse = await retrieveDiaryDefault(diary_id);
+    const getDiaryContentResponse = await retrieveDiaryContent(diary_id);
+
+    const getDiaryDetailResponse = {successResponse, getDiaryTitleResponse, getDiaryHashtagResponse, getDiaryDefaultResponse, getDiaryContentResponse}
+    return res.send(getDiaryDetailResponse);
+
+}
 
 export const postDiary = async (req, res) => {
     // body를 "기본 정보, 내용(글과 이미지), 해시 태그로 나누려고 함.
@@ -78,7 +106,7 @@ export const putDiary = async (req, res) => {
 
 export const deleteDiary = async (req, res) => {
     const user_id = req.verifiedToken.id;
-    const  { diary_id } = req.params;
+    const { diary_id } = req.params;
     // 빈 아이디 체크
     if (!user_id) return res.send(errResponse(baseResponse.USER_USERID_EMPTY));
     if (!diary_id) return res.send(errResponse(baseResponse.DIARY_DIARYID_EMPTY));

--- a/src/app/Diary/diaryDao.js
+++ b/src/app/Diary/diaryDao.js
@@ -139,3 +139,46 @@ export const deleteDiarybyId = async (connection, diary_id) => {
     const deleteDiarybyIdRows = await connection.query(deleteDiarybyIdQuery, diary_id);
     return deleteDiarybyIdRows;
 };
+
+export const selectDiaryDefault = async (connection, diary_id) => {
+    const selectDiaryDefaultQuery = `
+    SELECT diary.user_id, user.nickname, diary.updated_at,
+           diary.likes_count, diary.comments_count, diary.planner_id
+    FROM diary
+    INNER JOIN user
+    ON diary.user_id = user.id
+    WHERE diary.id = ? ;`;
+
+    const selectDiaryDefaultRows = await connection.query(selectDiaryDefaultQuery, diary_id);
+    return selectDiaryDefaultRows;
+};
+
+export const selectDiaryContent = async (connection, diary_id) => {
+    const selectDiaryContentQuery = `
+    SELECT count, type, content, location
+    FROM diary_content
+    WHERE diary_id = ? ;`;
+
+    const selectDiaryContentRows = await connection.query(selectDiaryContentQuery, diary_id);
+    return selectDiaryContentRows;
+};
+
+export const selectDiaryHashtag = async (connection, diary_id) => {
+    const selectDiaryHashtagQuery = `
+    SELECT tag
+    FROM diary_hashtag
+    WHERE diary_id = ? ;`;
+
+    const selectDiaryHashtagRows = await connection.query(selectDiaryHashtagQuery, diary_id);
+    return selectDiaryHashtagRows;
+};
+
+export const selectDiaryTitle = async (connection, diary_id) => {
+    const selectDiaryTitleQuery = `
+    SELECT title
+    FROM diary
+    WHERE id = ? ;`;
+
+    const selectDiaryTitleRows = await connection.query(selectDiaryTitleQuery, diary_id);
+    return selectDiaryTitleRows;
+};

--- a/src/app/Diary/diaryProvider.js
+++ b/src/app/Diary/diaryProvider.js
@@ -2,7 +2,16 @@ import pool from '../../../config/database';
 import { response, errResponse } from '../../../config/response';
 import baseResponse from '../../../config/baseResponseStatus';
 import { selectUserbyId } from '../User/userDao';
-import { selectDiaryListById, selectDiaryId, selectDiarybyId, selectUserbyDiaryId } from "./diaryDao";
+import {
+    selectDiaryListById,
+    selectDiaryId,
+    selectDiarybyId,
+    selectUserbyDiaryId,
+    selectDiaryDefault,
+    selectDiaryContent,
+    selectDiaryHashtag,
+    selectDiaryTitle
+} from "./diaryDao";
 
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
@@ -58,6 +67,46 @@ export const retrieveDiaryList = async (user_id) => {
         return errResponse(baseResponse.DAIRY_DIARYID_NOT_EXIST);
     }
 };
+
+// 다이어리 제목 정보(제목)
+export const retrieveDiaryTitle = async (diary_id) => {
+    const connection = await pool.getConnection(async (conn) => conn);
+    const retrieveDiaryTitleResult = await selectDiaryTitle(connection, diary_id);
+
+    connection.release();
+    return retrieveDiaryTitleResult[0];
+}
+
+// 다이어리 태그 정보(해시태그)
+export const retrieveDiaryHashtag = async (diary_id) => {
+    const connection = await pool.getConnection(async (conn) => conn);
+    const retrieveDiaryHashtagResult = await selectDiaryHashtag(connection, diary_id);
+
+    connection.release();
+    return retrieveDiaryHashtagResult[0];
+}
+
+// 다이어리 기본 정보(작성자, 작성 날짜 등)
+export const retrieveDiaryDefault = async (diary_id) => {
+    const connection = await pool.getConnection(async (conn) => conn);
+    const retrieveDiaryDefaultResult = await selectDiaryDefault(connection, diary_id);
+    // 시간대를 한국 시간대로 바꾸는 과정
+    const updatedTimeUTC = dayjs(retrieveDiaryDefaultResult[0][0].updated_at).utc();
+    const updatedTimeKorea = updatedTimeUTC.tz('Asia/Seoul');
+    retrieveDiaryDefaultResult[0][0].updated_at = updatedTimeKorea.format('YYYY-MM-DD HH:mm:ss');
+
+    connection.release();
+    return retrieveDiaryDefaultResult[0];
+}
+
+// 다이어리 내용 정보(글, 사진 등)
+export const retrieveDiaryContent = async (diary_id) => {
+    const connection = await pool.getConnection(async (conn) => conn);
+    const retrieveDiaryContentResult = await selectDiaryContent(connection, diary_id);
+
+    connection.release();
+    return retrieveDiaryContentResult[0];
+}
 
 export const retrieveDiaryId = async (user_id) => {
     // 방금 만든 Diary의 id를 받아오기 위함

--- a/src/app/Diary/diaryRoute.js
+++ b/src/app/Diary/diaryRoute.js
@@ -3,6 +3,7 @@ import { jwtMiddleware } from '../../../config/jwtMiddleware';
 import {
     getDiaryList,
     getDiaryListAll,
+    getDiaryDetail,
     deleteDiary,
     postDiary,
     putDiary
@@ -12,6 +13,7 @@ import {
 const diaryRouter = express.Router();
 
 diaryRouter.get('/list', jwtMiddleware, getDiaryListAll);
+diaryRouter.get('/:diary_id', jwtMiddleware, getDiaryDetail);
 diaryRouter.get('/list/mydiary', jwtMiddleware, getDiaryList);
 diaryRouter.delete('/:diary_id', jwtMiddleware, deleteDiary);
 diaryRouter.post('/', jwtMiddleware, postDiary);


### PR DESCRIPTION
output은 크게 5가지로 나뉩니다.
디자인 보면서 최대한 순서 맞춰서 받아오도록 했어요

> successResponse - 성공 응답
getDiaryTitleResponse - 제목 
getDiaryHashtagResponse - 해시태그
getDiaryDefaultResponse - 유저 닉네임, 작성 날짜, 좋아요 수, 댓글 수 ,관련된 플래너 id
getDiaryContentResponse - 내용(글, 사진)


만약 데이터베이스에 파라미터로 담아서 요청했던 diary_id와 일치하는 다이어리가 없다면 아래와 같은 응답을 줍니다. 
![image](https://github.com/UMC-SAVVY/SAVVY_Server/assets/122192096/0c0a564d-25e8-42e4-9a9a-743d6ab754f3)
