### PR TITLE
Add : 다이어리 홈 조회 API 추가

### DIFF
--- a/config/baseResponseStatus.js
+++ b/config/baseResponseStatus.js
@@ -261,6 +261,17 @@ const baseResponse = {
     code: 2412,
     message: '다이어리 상태를 비공개로 바꾸려고 하지만, 이미 비공개 상태입니다.'
   },
+  DIARY_DAIRY_ID_INVALID: {
+    isSuccess: false,
+    code: 2413,
+    message: 'diary_id의 값이 숫자가 아닙니다.'
+  },
+  DAIRY_NOT_EXIST_SHOWN_DIARY: {
+    isSuccess: false,
+    code: 2414,
+    message: '더 이상 보여줄 다이어리가 없습니다.'
+
+  },
 
   // Response error
   SIGNUP_REDUNDANT_EMAIL: {

--- a/src/app/Diary/diaryController.js
+++ b/src/app/Diary/diaryController.js
@@ -2,7 +2,9 @@ import { errResponse, response } from '../../../config/response';
 import baseResponse from '../../../config/baseResponseStatus';
 import {
     retrieveDiaryList,
-    retrieveDiaryDetail
+    retrieveDiaryDetail,
+    retrieveHomeListdefault,
+    retrieveHomeListbyId
 } from './diaryProvider';
 import {
     createDiary,
@@ -120,7 +122,7 @@ export const postDiaryImage = async(req, res) => {
     }
     if (!fileResponse) return res.send(errResponse(baseResponse.S3_ERROR));
     return res.send(response(baseResponse.SUCCESS, fileResponse));
-}
+};
 
 export const ModifyStatus = async(req, res) => {
     const user_id = req.verifiedToken.id;
@@ -145,11 +147,22 @@ export const ModifyStatus = async(req, res) => {
         const modifyPublicStatusResponse = await updatedPublicStatus(user_id, diary_id, value);
         return res.send(modifyPublicStatusResponse);
     }
+};
 
-
-
-
-
-
-}
+export const getHomeList = async(req, res) => {
+    const user_id = req.verifiedToken.id;
+    const { diary_id } = req.query;
+    // 빈 아이디 체크
+    if (!user_id) return res.send(errResponse(baseResponse.USER_USERID_EMPTY));
+    //처음 홈에서 글을 불러오는 경우, 쿼리가 비어있어야 한다.
+    if (!diary_id) {
+        const getHomeListResponse = await retrieveHomeListdefault(user_id);
+        return res.send(getHomeListResponse);
+    } else {    // 다이어리 아이디가 비어있지 않지만, 숫자가 아닌 경우
+        if (isNaN(diary_id) === true) return res.send(errResponse(baseResponse.DIARY_DAIRY_ID_INVALID));
+        // diary_id에 정상적으로 마지막 조회한 글의 id가 담긴다.
+        const getHomeListResponse = await retrieveHomeListbyId(user_id, diary_id);
+        return res.send(getHomeListResponse);
+    }
+};
 

--- a/src/app/Diary/diaryDao.js
+++ b/src/app/Diary/diaryDao.js
@@ -273,3 +273,42 @@ export const checkPublicStatus = async (connection, diary_id) => {
     const checkPublicStatusRows = await connection.query(checkPublicStatusQuery, diary_id);
     return checkPublicStatusRows;
 }
+
+export const selectHomeListdefault = async (connection, user_id) => {
+    const selectHomeListdefaultQuery = `
+    SELECT id, title, user_id, updated_at, likes_count, comments_count, thumbnail,
+    likes_count, comments_count
+    FROM diary
+    WHERE user_id NOT IN (SELECT blocked_user FROM user_blocked WHERE user_id = ?) AND 
+    is_public = 'true'
+    ORDER BY updated_at DESC LIMIT 20;`;
+
+    const selectHomeListdefaultRows = await connection.query(selectHomeListdefaultQuery, user_id);
+    return selectHomeListdefaultRows;
+}
+
+
+export const selectHomeListbyId = async (connection, params) => {
+    const selectHomeListbyIdQuery = ` 
+    SELECT id, title, user_id, updated_at, likes_count, comments_count, thumbnail,
+    likes_count, comments_count
+    FROM diary
+    WHERE updated_at < (SELECT updated_at FROM diary WHERE id = ?) AND
+          user_id NOT IN (SELECT blocked_user FROM user_blocked WHERE user_id = ?) AND 
+          is_public = 'true'
+    ORDER BY updated_at DESC LIMIT 20;`;
+
+    const selectHomeListbyIdRows = await connection.query(selectHomeListbyIdQuery, params);
+    return selectHomeListbyIdRows;
+
+}
+
+export const findUserNickname = async (connection, user_id) => {
+    const findUserNicknameQuery = ` 
+    SELECT nickname
+    FROM user
+    WHERE id = ? ;`;
+
+    const findUserNicknameRows = await connection.query(findUserNicknameQuery, user_id);
+    return findUserNicknameRows;
+}

--- a/src/app/Diary/diaryProvider.js
+++ b/src/app/Diary/diaryProvider.js
@@ -10,7 +10,10 @@ import {
     selectDiaryDefault,
     selectDiaryContent,
     selectDiaryHashtag,
-    selectIsLiked
+    selectIsLiked,
+    selectHomeListdefault,
+    selectHomeListbyId,
+    findUserNickname
 } from "./diaryDao";
 
 const dayjs = require('dayjs');
@@ -113,4 +116,65 @@ export const retrieveDiaryId = async (user_id) => {
     connection.release();
     return retrieveDiaryIdResult;
 };
+
+export const retrieveHomeListdefault = async (user_id) => {
+    // user가 존재하는지 체크
+    const userExist = await userIdCheck(user_id);
+    if (!userExist[0][0]) {
+        return errResponse(baseResponse.USER_USERID_NOT_EXIST);
+    }
+    const connection = await pool.getConnection(async (conn) => conn);
+    const retrieveHomeListdefaultResult = await selectHomeListdefault(connection, user_id);
+    if(!retrieveHomeListbyIdResult[0][0]) return errResponse(baseResponse.DAIRY_NOT_EXIST_SHOWN_DIARY);
+    for(let i = 0; i < retrieveHomeListdefaultResult[0].length; i++) {
+        //작성자 닉네임 받아오기
+        const findNickname = await findUserNickname(connection, retrieveHomeListdefaultResult[0][i].user_id);
+        retrieveHomeListdefaultResult[0][i].nickname = findNickname[0][0].nickname;
+        //작성한 다이어리 해시태그 받아오기
+        const hashtagInfo = await selectDiaryHashtag(connection, retrieveHomeListdefaultResult[0][i].id);
+        retrieveHomeListdefaultResult[0][i].hashtag = hashtagInfo[0];
+        //dayjs를 사용, 시간을 한국 시간대로 변경해 YYYY-MM-DD 형식으로 변환하는 과정.
+        const updatedTimeUTC = dayjs(retrieveHomeListdefaultResult[0][i].updated_at).utc();
+        const updatedTimeKorea = updatedTimeUTC.tz('Asia/Seoul');
+        retrieveHomeListdefaultResult[0][i].updated_at = updatedTimeKorea.format('YYYY.MM.DD');
+    }
+    connection.release();
+    return retrieveHomeListdefaultResult[0];
+
+}
+
+export const retrieveHomeListbyId = async (user_id, diary_id) => {
+    // user가 존재하는지 체크
+    const userExist = await userIdCheck(user_id);
+    if (!userExist[0][0]) {
+        return errResponse(baseResponse.USER_USERID_NOT_EXIST);
+    }
+    // diary가 존재하는지 체크
+    const diaryExist = await diaryIdCheck(diary_id);
+    if (!diaryExist[0][0]) {
+        return errResponse(baseResponse.DAIRY_DIARYID_NOT_EXIST);
+    }
+    const connection = await pool.getConnection(async (conn) => conn);
+    const retrieveHomeListbyIdResult = await selectHomeListbyId(connection, [
+        diary_id,
+        user_id
+    ]);
+    if(!retrieveHomeListbyIdResult[0][0]) return errResponse(baseResponse.DAIRY_NOT_EXIST_SHOWN_DIARY);
+    for(let i = 0; i < retrieveHomeListbyIdResult[0].length; i++) {
+        //작성자 닉네임 받아오기
+        const findNickname = await findUserNickname(connection, retrieveHomeListbyIdResult[0][i].user_id);
+        retrieveHomeListbyIdResult[0][i].nickname = findNickname[0][0].nickname;
+        //작성한 다이어리 해시태그 받아오기
+        const hashtagInfo = await selectDiaryHashtag(connection, retrieveHomeListbyIdResult[0][i].id);
+        retrieveHomeListbyIdResult[0][i].hashtag = hashtagInfo[0];
+        //dayjs를 사용, 시간을 한국 시간대로 변경해 YYYY-MM-DD 형식으로 변환하는 과정.
+        const updatedTimeUTC = dayjs(retrieveHomeListbyIdResult[0][i].updated_at).utc();
+        const updatedTimeKorea = updatedTimeUTC.tz('Asia/Seoul');
+        retrieveHomeListbyIdResult[0][i].updated_at = updatedTimeKorea.format('YYYY.MM.DD');
+    }
+
+    connection.release();
+    return retrieveHomeListbyIdResult[0];
+
+}
 

--- a/src/app/Diary/diaryRoute.js
+++ b/src/app/Diary/diaryRoute.js
@@ -10,12 +10,14 @@ import {
     postDiary,
     putDiary,
     postDiaryImage,
-    ModifyStatus
+    ModifyStatus,
+    getHomeList
 } from './diaryController';
 
 const diaryRouter = express.Router();
 
 diaryRouter.get('/list', jwtMiddleware, wrapAsync(getDiaryListAll));
+diaryRouter.get('/home', jwtMiddleware, wrapAsync(getHomeList));
 diaryRouter.get('/:diary_id', jwtMiddleware, wrapAsync(getDiaryDetail));
 diaryRouter.get('/list/mydiary', jwtMiddleware, wrapAsync(getDiaryList));
 diaryRouter.delete('/:diary_id', jwtMiddleware, wrapAsync(deleteDiary));
@@ -27,7 +29,7 @@ diaryRouter.post(
   uploadImage.array('image', 10),
   wrapAsync(postDiaryImage)
 );
-diaryRouter.post('/status', jwtMiddleware, ModifyStatus);
+diaryRouter.post('/status', jwtMiddleware, wrapAsync(ModifyStatus));
 
 
 export default diaryRouter;

--- a/src/app/Diary/diaryService.js
+++ b/src/app/Diary/diaryService.js
@@ -30,30 +30,24 @@ import {
 
 export const deleteDiaryCheck = async (user_id, diary_id) => {
     // user가 존재하는지 체크
-    const userExist = await userIdCheck(defaultInfo.user_id);
+    const userExist = await userIdCheck(user_id);
     if (!userExist[0][0]) {
         return errResponse(baseResponse.USER_USERID_NOT_EXIST);
-        // 다이어리 작성자 user_id와 삭제를 시도하는 user_id가 같은지 체크
-        const diaryOwnermatch = await diaryOwnerMatchCheck(diary_id);
-        if (user_id != diaryOwnermatch[0][0].user_id) {
-            return errResponse(baseResponse.USER_USERID_NOT_MATCH_DIARYOWNER);
-        }
-        const diaryExist = await diaryIdCheck(diary_id);
-        // diary가 존재하는지 체크
-        if (!myDiaryCheck[0][0]) {
-            return errResponse(baseResponse.DAIRY_DIARYID_NOT_EXIST);
-        }
-        // 다이어리 작성자 user_id와 삭제를 시도하는 user_id가 같은지 체크
-        if (user_id != diaryExist[0][0].user_id) {
-            return errResponse(baseResponse.USER_USERID_NOT_MATCH_DIARYOWNER);
-        }
+    }
+    // diary가 존재하는지 체크
+    const diaryExist = await diaryIdCheck(diary_id);
+    if (!diaryExist[0][0]) {
+        return errResponse(baseResponse.DAIRY_DIARYID_NOT_EXIST);
+    }
+    // 다이어리 작성자 user_id와 삭제를 시도하는 user_id가 같은지 체크
+    if (user_id != diaryExist[0][0].user_id) {
+        return errResponse(baseResponse.USER_USERID_NOT_MATCH_DIARYOWNER);
+    }
         const connection = await pool.getConnection(async (conn) => conn);
         const deleteDiarybyIdResult = await deleteDiarybyId(connection, diary_id);
-
         connection.release();
         return response(baseResponse.SUCCESS);
-    }
-};
+    };
 
 export const createDiary = async (defaultInfo, contentInfo, hashtagInfo) => {
     // user가 존재하는지 체크


### PR DESCRIPTION
1. 조회 시 한번에 가져오는 다이어리 수는 최대 20개(페이징 적용)
2. 정렬은 최신순(내림차순으로 가져온다)
3. is_public이 true인 글만 가져온다
4. 유저 차단 여부를 반영한다.

<조회 방법>
- 처음 홈 조회 시(쿼리스트링으로 diary_id 달지 않는 경우) 최신 순으로 20개 가져온다. 
- 마지막으로 조회한 diary_id를 쿼리스트링으로 달아주면 그 다이어리보다 오래된 글들로 20개 가져온다.
- 더 이상 조회할 다이어리가 없다면 "더 이상 보여줄 다이어리가 없습니다." 라는 errResponse를 보낸다.